### PR TITLE
Paginate thru list of jobs instead of fetching first page only

### DIFF
--- a/gitlab_jobs.py
+++ b/gitlab_jobs.py
@@ -30,6 +30,19 @@ def get_pipelines(project, args):
             yield pipeline
 
 
+def get_jobs(pipeline, scope, all):
+    page = 0
+    while True:
+        page += 1
+
+        jobs = pipeline.jobs.list(
+                scope=scope, all=all, page=page, per_page=100)
+        if len(jobs) == 0:
+            raise StopIteration()
+        for job in jobs:
+            yield job
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -100,7 +113,7 @@ def main():
         duration_min = pipeline.duration / 60.0
         print(template.format(
             duration_min=duration_min, **pipeline.attributes))
-        for job in pipeline.jobs.list(scope='success', all=True):
+        for job in get_jobs(pipeline, scope='success', all=True):
             job_durations[job.name].append(job.duration)
             if args.verbose:
                 print("    {name:30}  {duration_min:4.1f}m".format(


### PR DESCRIPTION
While using this tool as the basis for some long-term metrics analysis, I noticed an issue in how many CI jobs were being reported. Digging into it, I found that `pipeline.jobs.list()` will make an API call that by default, will only return the first page of jobs, with the default page size being 20 jobs. As a result, the data is not always correct for pipelines with more than 20 jobs.

To fix this, I'm adding a new generator function based on `get_pipelines` from my previous PR, but a bit simpler since we always want to get all the jobs back. With this change, I'm able to properly get all the jobs for a pipeline, and so the metrics are more accurate.